### PR TITLE
コンテンツが画面の左右いっぱいに広がっているので、コンテンツ幅を一定として、左右にスペースを開ける

### DIFF
--- a/src/pages/TopPage.tsx
+++ b/src/pages/TopPage.tsx
@@ -1,21 +1,21 @@
 import React from 'react'
 
 export const TopPage = () => {
-  return (
-    <div>
-        <header>
-            <div className="flex justify-between" >
-                <p>スケジュール管理App</p>
-                <nav>
-                    <ul className='flex gap-5'>
-                        <li>ご利用方法</li>
-                        <li>ログイン</li>
-                    </ul>
-                </nav>
-            </div>
+    return (
+      <div className="relative">
+        <header className="leading-[50px] fixed top-0 left-0 right-0">
+          <div className="container mx-auto flex justify-between">
+            <p className="logo">スケジュール管理APP</p>
+            <nav>
+              <ul className="flex gap-5 text-lime-800">
+                <li>ご利用方法</li>
+                <li>ログイン</li>
+              </ul>
+            </nav>
+          </div>
         </header>
-    </div>
-   )
+      </div>
+    );
 }
 
 export default TopPage;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,3 +1,16 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.logo {
+    color          : #ffffff;
+    text-shadow    : 
+        1px  1px 1px #3f6212,
+      -1px  1px 1px #3f6212,
+        1px -1px 1px #3f6212,
+      -1px -1px 1px #3f6212,
+        1px  0px 1px #3f6212,
+        0px  1px 1px #3f6212,
+      -1px  0px 1px #3f6212,
+        0px -1px 1px #3f6212;
+  }


### PR DESCRIPTION
#### wiki


#### 変更点
- src/pages/TopPage.tsx
- src/styles/index.css

<img width="1412" alt="スクリーンショット 2024-06-24 0 13 57" src="https://github.com/Hashimoto-Noriaki/next-calender-project/assets/73786052/0686bce0-7095-4fb2-92ac-b6bd68d123ab">
