### PR TITLE
ログインページのタグ構成、レイアウト作成

### DIFF
--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,9 +1,30 @@
-import React from 'react'
+import { PrimaryBtn } from "../components/atoms/PrimaryBtn";
 
 export const Login = () => {
   return (
-    <div>LoginPage</div>
-  )
-}
+    <div className="w-[500px] bg-white rounded-lg shadow-lg py-10">
+      <form className="flex flex-col justify-center items-center gap-10">
+        <h1 className="text-3xl text-lime-800 font-bold text-center">
+          ログイン
+        </h1>
+        <div className="w-[80%]">
+          <input
+            type="text"
+            className="w-full border-4 border-solid border-lime-800 rounded-md p-2"
+            placeholder="email"
+          />
+        </div>
+        <div className="w-[80%]">
+          <input
+            type="password"
+            className="w-full border-4 border-solid border-lime-800 rounded-md p-2"
+            placeholder="password"
+          />
+        </div>
+        <PrimaryBtn>ログイン</PrimaryBtn>
+      </form>
+    </div>
+  );
+};
 
 export default Login;


### PR DESCRIPTION
### wiki

https://github.com/Hashimoto-Noriaki/next-calender-project/wiki/%E6%89%8B%E9%A0%8611-%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%83%9A%E3%83%BC%E3%82%B8%E4%BD%9C%E6%88%902

### 変更点
- src/pages/login.tsx

### 想定画像

<img width="1434" alt="スクリーンショット 2024-06-27 1 54 30" src="https://github.com/Hashimoto-Noriaki/next-calender-project/assets/73786052/66d8889e-fe02-490d-91bd-0a73d0477d1d">
